### PR TITLE
Add metadata to compute plan

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -30,7 +30,7 @@ Smart contract: `registerDataManager`
      "authorizedIDs": [string] (required),
    },
  },
- "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
+ "metadata": map (lte=100,dive,keys,lte=50,endkeys,lte=100),
 }
 ```
 ##### Command peer example:
@@ -127,7 +127,7 @@ Smart contract: `registerObjective`
      "authorizedIDs": [string] (required),
    },
  },
- "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
+ "metadata": map (lte=100,dive,keys,lte=50,endkeys,lte=100),
 }
 ```
 ##### Command peer example:
@@ -157,7 +157,7 @@ Smart contract: `registerAlgo`
      "authorizedIDs": [string] (required),
    },
  },
- "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
+ "metadata": map (lte=100,dive,keys,lte=50,endkeys,lte=100),
 }
 ```
 ##### Command peer example:
@@ -317,7 +317,7 @@ Smart contract: `createTraintuple`
  "computePlanID": string (omitempty),
  "rank": string (omitempty),
  "tag": string (omitempty,lte=64),
- "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
+ "metadata": map (lte=100,dive,keys,lte=50,endkeys,lte=100),
 }
 ```
 ##### Command peer example:
@@ -343,7 +343,7 @@ Smart contract: `createTraintuple`
  "computePlanID": string (omitempty),
  "rank": string (omitempty),
  "tag": string (omitempty,lte=64),
- "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
+ "metadata": map (lte=100,dive,keys,lte=50,endkeys,lte=100),
 }
 ```
 ##### Command peer example:
@@ -1351,6 +1351,7 @@ Smart contract: `createComputePlan`
 ```go
 {
  "tag": string (omitempty,lte=64),
+ "metadata": map (lte=100,dive,keys,lte=50,endkeys,lte=100),
  "traintuples": (omitempty) [{
    "dataManagerKey": string (required,len=64,hexadecimal),
    "dataSampleKeys": [string] (required,dive,len=64,hexadecimal),
@@ -1358,12 +1359,14 @@ Smart contract: `createComputePlan`
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
  }],
  "aggregatetuples": (omitempty) [{
    "algoKey": string (required,len=64,hexadecimal),
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
    "worker": string (required),
  }],
  "compositeTraintuples": (omitempty) [{
@@ -1380,19 +1383,21 @@ Smart contract: `createComputePlan`
      },
    },
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
  }],
  "testtuples": (omitempty) [{
    "dataManagerKey": string (omitempty,len=64,hexadecimal),
    "dataSampleKeys": [string] (omitempty,dive,len=64,hexadecimal),
    "objectiveKey": string (required,len=64,hexadecimal),
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
    "traintupleID": string (required,lte=64),
  }],
 }
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"cleanModels\":false,\"tag\":\"a tag is simply a string\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\"},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\"}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"cleanModels\":false,\"tag\":\"a tag is simply a string\",\"metadata\":null,\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"firstTraintupleID\",\"inModelsIDs\":null,\"tag\":\"\",\"metadata\":null},{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"secondTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\"],\"tag\":\"\",\"metadata\":null}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"metadata\":null,\"traintupleID\":\"secondTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -1406,6 +1411,7 @@ peer chaincode invoke -n mycc -c '{"Args":["createComputePlan","{\"cleanModels\"
  "compositeTraintupleKeys": null,
  "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
  "doneCount": 0,
+ "metadata": {},
  "status": "todo",
  "tag": "a tag is simply a string",
  "testtupleKeys": [
@@ -1432,12 +1438,14 @@ Smart contract: `updateComputePlan`
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
  }],
  "aggregatetuples": (omitempty) [{
    "algoKey": string (required,len=64,hexadecimal),
    "id": string (required,lte=64),
    "inModelsIDs": [string] (omitempty,dive,lte=64),
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
    "worker": string (required),
  }],
  "compositeTraintuples": (omitempty) [{
@@ -1454,19 +1462,21 @@ Smart contract: `updateComputePlan`
      },
    },
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
  }],
  "testtuples": (omitempty) [{
    "dataManagerKey": string (omitempty,len=64,hexadecimal),
    "dataSampleKeys": [string] (omitempty,dive,len=64,hexadecimal),
    "objectiveKey": string (required,len=64,hexadecimal),
    "tag": string (omitempty,lte=64),
+   "metadata": map (omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100),
    "traintupleID": string (required,lte=64),
  }],
 }
 ```
 ##### Command peer example:
 ```bash
-peer chaincode invoke -n mycc -c '{"Args":["updateComputePlan","{\"computePlanID\":\"7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"thirdTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\",\"secondTraintupleID\"],\"tag\":\"\"}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"traintupleID\":\"thirdTraintupleID\"}]}"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["updateComputePlan","{\"computePlanID\":\"7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17\",\"traintuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"aa1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"algoKey\":\"fd1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"id\":\"thirdTraintupleID\",\"inModelsIDs\":[\"firstTraintupleID\",\"secondTraintupleID\"],\"tag\":\"\",\"metadata\":null}],\"aggregatetuples\":null,\"compositeTraintuples\":null,\"testtuples\":[{\"dataManagerKey\":\"da1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"dataSampleKeys\":[\"bb1bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\",\"bb2bb7c31f62244c0f3a761cc168804227115793d01c270021fe3f7935482dcc\"],\"objectiveKey\":\"5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b379\",\"tag\":\"\",\"metadata\":null,\"traintupleID\":\"thirdTraintupleID\"}]}"]}' -C myc
 ```
 ##### Command output:
 ```json
@@ -1479,6 +1489,7 @@ peer chaincode invoke -n mycc -c '{"Args":["updateComputePlan","{\"computePlanID
  "compositeTraintupleKeys": null,
  "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
  "doneCount": 0,
+ "metadata": {},
  "status": "todo",
  "tag": "a tag is simply a string",
  "testtupleKeys": [
@@ -1578,6 +1589,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlan","{\"key\":\"7dd808
  "compositeTraintupleKeys": null,
  "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
  "doneCount": 0,
+ "metadata": {},
  "status": "todo",
  "tag": "a tag is simply a string",
  "testtupleKeys": [
@@ -1606,6 +1618,7 @@ peer chaincode invoke -n mycc -c '{"Args":["queryComputePlans"]}' -C myc
   "compositeTraintupleKeys": null,
   "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
   "doneCount": 0,
+  "metadata": {},
   "status": "todo",
   "tag": "a tag is simply a string",
   "testtupleKeys": [
@@ -1643,6 +1656,7 @@ peer chaincode invoke -n mycc -c '{"Args":["cancelComputePlan","{\"key\":\"7dd80
  "compositeTraintupleKeys": null,
  "computePlanID": "7dd808239c1e062399449bd11b634d9bd1fd0a2b795ad345b62f95b4933bfa17",
  "doneCount": 0,
+ "metadata": {},
  "status": "canceled",
  "tag": "a tag is simply a string",
  "testtupleKeys": [

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -109,7 +109,7 @@ func createComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err
 	if err != nil {
 		return
 	}
-	return createComputePlanInternal(db, inp.inputComputePlan, inp.Tag, inp.CleanModels)
+	return createComputePlanInternal(db, inp.inputComputePlan, inp.Tag, inp.Metadata, inp.CleanModels)
 }
 
 func updateComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err error) {
@@ -129,10 +129,11 @@ func updateComputePlan(db *LedgerDB, args []string) (resp outputComputePlan, err
 	return updateComputePlanInternal(db, inp.ComputePlanID, inp.inputComputePlan)
 }
 
-func createComputePlanInternal(db *LedgerDB, inp inputComputePlan, tag string, cleanModels bool) (resp outputComputePlan, err error) {
+func createComputePlanInternal(db *LedgerDB, inp inputComputePlan, tag string, metadata map[string]string, cleanModels bool) (resp outputComputePlan, err error) {
 	var computePlan ComputePlan
 	computePlan.State.Status = StatusWaiting
 	computePlan.Tag = tag
+	computePlan.Metadata = metadata
 	computePlan.CleanModels = cleanModels
 	ID, err := computePlan.Create(db)
 	if err != nil {

--- a/chaincode/compute_plan.go
+++ b/chaincode/compute_plan.go
@@ -24,6 +24,7 @@ func (inpTraintuple *inputTraintuple) Fill(inpCP inputComputePlanTraintuple, IDT
 	inpTraintuple.DataSampleKeys = inpCP.DataSampleKeys
 	inpTraintuple.AlgoKey = inpCP.AlgoKey
 	inpTraintuple.Tag = inpCP.Tag
+	inpTraintuple.Metadata = inpCP.Metadata
 
 	// Set the inModels by matching the id to tuples key previously
 	// encontered in this compute plan
@@ -41,6 +42,7 @@ func (inpTraintuple *inputTraintuple) Fill(inpCP inputComputePlanTraintuple, IDT
 func (inpAggregatetuple *inputAggregatetuple) Fill(inpCP inputComputePlanAggregatetuple, IDToTrainTask map[string]TrainTask) error {
 	inpAggregatetuple.AlgoKey = inpCP.AlgoKey
 	inpAggregatetuple.Tag = inpCP.Tag
+	inpAggregatetuple.Metadata = inpCP.Metadata
 	inpAggregatetuple.Worker = inpCP.Worker
 
 	// Set the inModels by matching the id to tuples key previously
@@ -61,6 +63,7 @@ func (inpCompositeTraintuple *inputCompositeTraintuple) Fill(inpCP inputComputeP
 	inpCompositeTraintuple.DataSampleKeys = inpCP.DataSampleKeys
 	inpCompositeTraintuple.AlgoKey = inpCP.AlgoKey
 	inpCompositeTraintuple.Tag = inpCP.Tag
+	inpCompositeTraintuple.Metadata = inpCP.Metadata
 	inpCompositeTraintuple.OutTrunkModelPermissions = inpCP.OutTrunkModelPermissions
 
 	// Set the inModels by matching the id to traintuples key previously
@@ -93,6 +96,7 @@ func (inpTesttuple *inputTesttuple) Fill(inpCP inputComputePlanTesttuple, IDToTr
 	inpTesttuple.DataManagerKey = inpCP.DataManagerKey
 	inpTesttuple.DataSampleKeys = inpCP.DataSampleKeys
 	inpTesttuple.Tag = inpCP.Tag
+	inpTesttuple.Metadata = inpCP.Metadata
 	inpTesttuple.ObjectiveKey = inpCP.ObjectiveKey
 
 	return nil

--- a/chaincode/compute_plan_test.go
+++ b/chaincode/compute_plan_test.go
@@ -162,7 +162,7 @@ func TestModelCompositionComputePlanWorkflow(t *testing.T) {
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, false)
+	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, db.event)
 	assert.Len(t, db.event.CompositeTraintuples, 2)
@@ -285,7 +285,7 @@ func TestCreateComputePlanCompositeAggregate(t *testing.T) {
 		},
 	}
 
-	outCP, err := createComputePlanInternal(db, inCP, tag, false)
+	outCP, err := createComputePlanInternal(db, inCP, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 
 	// Check the composite traintuples
@@ -327,7 +327,7 @@ func TestCreateComputePlan(t *testing.T) {
 
 	// Simply test method and return values
 	inCP := defaultComputePlan
-	outCP, err := createComputePlanInternal(db, inCP, tag, false)
+	outCP, err := createComputePlanInternal(db, inCP, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	validateDefaultComputePlan(t, outCP)
 
@@ -380,7 +380,7 @@ func TestQueryComputePlan(t *testing.T) {
 
 	// Simply test method and return values
 	inCP := defaultComputePlan
-	outCP, err := createComputePlanInternal(db, inCP, tag, false)
+	outCP, err := createComputePlanInternal(db, inCP, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
 
@@ -400,7 +400,7 @@ func TestQueryComputePlans(t *testing.T) {
 
 	// Simply test method and return values
 	inCP := defaultComputePlan
-	outCP, err := createComputePlanInternal(db, inCP, tag, false)
+	outCP, err := createComputePlanInternal(db, inCP, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
 
@@ -448,7 +448,7 @@ func TestComputePlanEmptyTesttuples(t *testing.T) {
 		Testtuples: []inputComputePlanTesttuple{},
 	}
 
-	outCP, err := createComputePlanInternal(db, inCP, tag, false)
+	outCP, err := createComputePlanInternal(db, inCP, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, outCP)
 	assert.Len(t, outCP.TesttupleKeys, 0)
@@ -485,7 +485,7 @@ func TestCancelComputePlan(t *testing.T) {
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, false)
+	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, db.event)
 	assert.Len(t, db.event.CompositeTraintuples, 2)
@@ -527,7 +527,7 @@ func TestStartedTuplesOfCanceledComputePlan(t *testing.T) {
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, false)
+	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 
 	logStartCompositeTrain(db, assetToArgs(inputKey{out.CompositeTraintupleKeys[0]}))
@@ -559,7 +559,7 @@ func TestLogSuccessAfterCancel(t *testing.T) {
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, false)
+	out, err := createComputePlanInternal(db, modelCompositionComputePlan, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 
 	logStartCompositeTrain(db, assetToArgs(inputKey{out.CompositeTraintupleKeys[0]}))
@@ -603,7 +603,7 @@ func TestComputePlanMetrics(t *testing.T) {
 	mockStub.MockTransactionStart("42")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, defaultComputePlan, tag, false)
+	out, err := createComputePlanInternal(db, defaultComputePlan, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	checkComputePlanMetrics(t, db, out.ComputePlanID, 0, 3)
 
@@ -655,7 +655,7 @@ func TestUpdateComputePlan(t *testing.T) {
 	registerItem(t, *mockStub, "aggregateAlgo")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, inputComputePlan{}, tag, false)
+	out, err := createComputePlanInternal(db, inputComputePlan{}, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, tag, out.Tag)
 
@@ -705,7 +705,7 @@ func TestCleanModels(t *testing.T) {
 	registerItem(t, *mockStub, "aggregateAlgo")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, defaultComputePlan, tag, true)
+	out, err := createComputePlanInternal(db, defaultComputePlan, tag, map[string]string{}, true)
 	assert.NoError(t, err)
 	// Just created the compute plan so not in the event
 	assert.Len(t, db.event.ComputePlans, 0)
@@ -741,7 +741,7 @@ func TestCreateSameComputePlanTwice(t *testing.T) {
 	registerItem(t, *mockStub, "aggregateAlgo")
 	db := NewLedgerDB(mockStub)
 
-	out, err := createComputePlanInternal(db, inputComputePlan{}, tag, false)
+	out, err := createComputePlanInternal(db, inputComputePlan{}, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, tag, out.Tag)
 
@@ -782,7 +782,7 @@ func TestCreateSameComputePlanTwice(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Upload the same tuples inside another compute plan
-	out, err = createComputePlanInternal(db, inputComputePlan{}, tag, false)
+	out, err = createComputePlanInternal(db, inputComputePlan{}, tag, map[string]string{}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, tag, out.Tag)
 

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -39,7 +39,7 @@ type inputObjective struct {
 	MetricsStorageAddress     string            `validate:"required,url" json:"metricsStorageAddress"`
 	TestDataset               inputDataset      `validate:"omitempty" json:"testDataset"`
 	Permissions               inputPermissions  `validate:"required" json:"permissions"`
-	Metadata                  map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata                  map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 // inputDataset is the representation in input args to register a dataset
@@ -56,7 +56,7 @@ type inputAlgo struct {
 	DescriptionHash           string            `validate:"required,len=64,hexadecimal" json:"descriptionHash"`
 	DescriptionStorageAddress string            `validate:"required,url" json:"descriptionStorageAddress"`
 	Permissions               inputPermissions  `validate:"required" json:"permissions"`
-	Metadata                  map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata                  map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 // inputDataManager is the representation of input args to register a DataManager
@@ -69,7 +69,7 @@ type inputDataManager struct {
 	DescriptionStorageAddress string            `validate:"required,url" json:"descriptionStorageAddress"`
 	ObjectiveKey              string            `validate:"omitempty" json:"objectiveKey"` //`validate:"required"`
 	Permissions               inputPermissions  `validate:"required" json:"permissions"`
-	Metadata                  map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata                  map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 // inputUpdateDataManager is the representation of input args to update a dataManager with a objective
@@ -100,7 +100,7 @@ type inputTraintuple struct {
 	ComputePlanID  string            `validate:"omitempty" json:"computePlanID"`
 	Rank           string            `validate:"omitempty" json:"rank"`
 	Tag            string            `validate:"omitempty,lte=64" json:"tag"`
-	Metadata       map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata       map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 // inputTestuple is the representation of input args to register a Testtuple
@@ -164,7 +164,7 @@ type inputComputePlan struct {
 type inputNewComputePlan struct {
 	CleanModels bool              `json:"cleanModels"` // whether or not to delete intermediary models
 	Tag         string            `validate:"omitempty,lte=64" json:"tag"`
-	Metadata    map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata    map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 	inputComputePlan
 }
 

--- a/chaincode/input.go
+++ b/chaincode/input.go
@@ -164,6 +164,7 @@ type inputComputePlan struct {
 type inputNewComputePlan struct {
 	CleanModels bool              `json:"cleanModels"` // whether or not to delete intermediary models
 	Tag         string            `validate:"omitempty,lte=64" json:"tag"`
+	Metadata    map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 	inputComputePlan
 }
 
@@ -181,6 +182,7 @@ type inputComputePlanTraintuple struct {
 	ID             string            `validate:"required,lte=64" json:"id"`
 	InModelsIDs    []string          `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
 	Tag            string            `validate:"omitempty,lte=64" json:"tag"`
+	Metadata       map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 type inputComputePlanAggregatetuple struct {
@@ -188,6 +190,7 @@ type inputComputePlanAggregatetuple struct {
 	ID          string            `validate:"required,lte=64" json:"id"`
 	InModelsIDs []string          `validate:"omitempty,dive,lte=64" json:"inModelsIDs"`
 	Tag         string            `validate:"omitempty,lte=64" json:"tag"`
+	Metadata    map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 	Worker      string            `validate:"required" json:"worker"`
 }
 
@@ -200,6 +203,7 @@ type inputComputePlanCompositeTraintuple struct {
 	InTrunkModelID           string            `validate:"required_with=InHeadModelID,omitempty,len=64,hexadecimal" json:"inTrunkModelID"`
 	OutTrunkModelPermissions inputPermissions  `validate:"required" json:"OutTrunkModelPermissions"`
 	Tag                      string            `validate:"omitempty,lte=64" json:"tag"`
+	Metadata                 map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 type inputComputePlanTesttuple struct {
@@ -207,6 +211,7 @@ type inputComputePlanTesttuple struct {
 	DataSampleKeys []string          `validate:"omitempty,dive,len=64,hexadecimal" json:"dataSampleKeys"`
 	ObjectiveKey   string            `validate:"required,len=64,hexadecimal" json:"objectiveKey"`
 	Tag            string            `validate:"omitempty,lte=64" json:"tag"`
+	Metadata       map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 	TraintupleID   string            `validate:"required,lte=64" json:"traintupleID"`
 }
 

--- a/chaincode/input_aggregate.go
+++ b/chaincode/input_aggregate.go
@@ -19,7 +19,7 @@ type inputAggregatetuple struct {
 	AlgoKey       string        	`validate:"required,len=64,hexadecimal" json:"algoKey"`
 	InModels      []string      	`validate:"omitempty,dive,len=64,hexadecimal" json:"inModels"`
 	ComputePlanID string        	`validate:"omitempty" json:"computePlanID"`
-	Metadata      map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata      map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 	Rank          string        	`validate:"omitempty" json:"rank"`
 	Tag           string        	`validate:"omitempty,lte=64" json:"tag"`
 	Worker        string        	`validate:"required" json:"worker"`

--- a/chaincode/input_composite.go
+++ b/chaincode/input_composite.go
@@ -25,7 +25,7 @@ type inputCompositeTraintuple struct {
 	ComputePlanID            string            `validate:"omitempty" json:"computePlanID"`
 	Rank                     string            `validate:"omitempty" json:"rank"`
 	Tag                      string            `validate:"omitempty,lte=64" json:"tag"`
-	Metadata                 map[string]string `validate:"omitempty,lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
+	Metadata                 map[string]string `validate:"lte=100,dive,keys,lte=50,endkeys,lte=100" json:"metadata"`
 }
 
 type inputCompositeAlgo struct {

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -353,7 +353,7 @@ func (out *outputComputePlan) Fill(key string, in ComputePlan, newIDs []string) 
 }
 
 type outputPermissions struct {
-	Process Permission `validate:"required" json:"process"`
+	Process Permission `json:"process"`
 }
 
 func (out *outputPermissions) Fill(in Permissions) {

--- a/chaincode/output.go
+++ b/chaincode/output.go
@@ -323,6 +323,7 @@ type outputComputePlan struct {
 	TesttupleKeys           []string          `json:"testtupleKeys"`
 	CleanModels             bool              `json:"cleanModels"`
 	Tag                     string            `json:"tag"`
+	Metadata                map[string]string `json:"metadata"`
 	Status                  string            `json:"status"`
 	TupleCount              int               `json:"tupleCount"`
 	DoneCount               int               `json:"doneCount"`
@@ -340,6 +341,7 @@ func (out *outputComputePlan) Fill(key string, in ComputePlan, newIDs []string) 
 	out.TesttupleKeys = in.TesttupleKeys
 	out.Status = in.State.Status
 	out.Tag = in.Tag
+	out.Metadata = initMapOutput(in.Metadata)
 	out.TupleCount = in.State.TupleCount
 	out.DoneCount = in.State.DoneCount
 	IDToKey := map[string]string{}


### PR DESCRIPTION
:link: **Related Pull Requests :**
• [substra](https://github.com/SubstraFoundation/substra/pull/189)
• [substra-tests](https://github.com/SubstraFoundation/substra-tests/pull/112)
• [substra-backend](https://github.com/SubstraFoundation/substra-backend/pull/273)

This PR aims to add a metadata field to the compute plan asset.